### PR TITLE
Fix Issue #16 - Change openpomodoro client init

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,21 +11,34 @@ import (
 	"github.com/spf13/viper"
 )
 
-// RootCmd represents the base command when called without any subcommands
-var RootCmd = &cobra.Command{
-	Use:   "pomodoro",
-	Short: "Pomodoro CLI",
-	Long:  "A simple Pomodoro command-line client for the Open Pomodoro format",
-}
-
 var (
 	client   *openpomodoro.Client
-	settings *openpomodoro.Settings
+	settings = &openpomodoro.DefaultSettings
 
 	directoryFlag string
 	formatFlag    string
 	waitFlag      bool
 )
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "pomodoro",
+	Short: "Pomodoro CLI",
+	Long:  "A simple Pomodoro command-line client for the Open Pomodoro format",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		client, err = openpomodoro.NewClient(directoryFlag)
+		if err != nil {
+			log.Fatalf("Could not create client: %v", err)
+		}
+
+		settings, err = client.Settings()
+		if err != nil {
+			log.Fatalf("Could not retrieve settings: %v", err)
+		}
+	},
+}
 
 func init() {
 	cobra.OnInitialize(initConfig)
@@ -43,18 +56,6 @@ func init() {
 		"wait for the Pomodoro to end before exiting")
 
 	viper.AutomaticEnv()
-
-	var err error
-
-	client, err = openpomodoro.NewClient(directoryFlag)
-	if err != nil {
-		log.Fatalf("Could not create client: %v", err)
-	}
-
-	settings, err = client.Settings()
-	if err != nil {
-		log.Fatalf("Could not retrieve settings: %v", err)
-	}
 }
 
 func initConfig() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-pomodoro/openpomodoro-cli
+module github.com/hugobally/openpomodoro-cli
 
 go 1.16
 


### PR DESCRIPTION
Fix for https://github.com/open-pomodoro/openpomodoro-cli/issues/16

The `--directory` flag does not work, all commands use the default `~/.pomodoro` directory even when the flag is provided. With the current code, `directoryFlag` is always an empty string when passed to the `openpomodoro.NewClient` function because the flag has not been parsed yet at this time.

Moving to the `PersistentPreRun` hook ensures that all commands will initialize the client with the correct flag value.

Tested on ArchLinux but I don´t think the issue is platform dependent.

Co-authored-by: hugobally <hugobally@users.noreply.github.com>