### PR TITLE
Remove duplicated %l format option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ Writing a blog post
 %g  - Daily Pomodoro goal
 %!g  - Daily Pomodoro goal, with a preceding slash
 %c  - Completed Pomodoros today
-%l  - Pomodoros remaining (left) to reach goal
 ```
 ## Hooks
 


### PR DESCRIPTION
The README claims that `%l` will print the length of the pomodoro and that `%l` will print pomodoros remaining to reach goal.
I see no implementation of the latter in `format/format.go` so I removed it from the README.