### PR TITLE
Fix Issue #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,12 @@ Hooks can be run when Pomodoros change state. There are 3 possible hooks:
 
 Commands which run hooks:
 
-* `break`: `break` immediately, `stop` when break is over
+* `break`: `break` immediately, `stop` when break is over, passing `break` as an argument.
 * `cancel`: `stop`
 * `clear`: `stop`
 * `finish`: `stop`
 * `repeat`: `start`
-* `start`: `start`
+* `start`: `start` immediately, `stop` when focus is over, passing `focus` as an argument.
 
 To enable a hook, create an executable file in the `hooks` subdirectory within your configuration directory. For example:
 

--- a/cmd/break.go
+++ b/cmd/break.go
@@ -40,7 +40,7 @@ func breakCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return hook.Run(client, "stop")
+	return hook.Run(client, "stop", "break")
 }
 
 func wait(d time.Duration) error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -55,5 +55,13 @@ func startCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return statusCmd(cmd, args)
+	if err := statusCmd(cmd, args); err != nil {
+		return err
+	}
+
+	if waitFlag {
+		return hook.Run(client, "stop")
+	}
+
+	return nil
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -60,7 +60,7 @@ func startCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if waitFlag {
-		return hook.Run(client, "stop")
+		return hook.Run(client, "stop", "focus")
 	}
 
 	return nil

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -10,14 +10,14 @@ import (
 )
 
 // Run runs a hook with the given name.
-func Run(client *openpomodoro.Client, name string) error {
+func Run(client *openpomodoro.Client, name string, args ...string) error {
 	filename := path.Join(client.Directory, "hooks", name)
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return nil
 	}
 
-	cmd := exec.Command(filename)
+	cmd := exec.Command(filename, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()


### PR DESCRIPTION
Fix for #30.

Additionally, the stop hook now receives a type argument ('focus' or 'break') when the timer runs out.