### PR TITLE
Add settings documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ The Pomodoro CLI can be configured using a `settings` file in your configuration
 ### Available Settings
 
 * `daily_goal` - The number of Pomodoros you want to complete each day (integer, default: 0 = no goal)
-* `default_pomodoro_duration` - Default duration for work sessions (duration string, default: "25m")
-* `default_break_duration` - Default duration for breaks (duration string, default: "5m")
+* `default_pomodoro_duration` - Default duration for work sessions (duration string, default: 25m)
+* `default_break_duration` - Default duration for breaks (duration string, default: 5m)
 * `default_tags` - Default tags to apply to new Pomodoros (comma-separated strings, default: none)
 
 ### Example Settings File
@@ -313,7 +313,8 @@ default_tags=work,focus
 ### Duration Format
 
 Duration values can be specified in the following formats:
-* Minutes: `25m`, `30m`
+* Plain numbers default to minutes: `25` = 25 minutes
+* Explicit minutes: `25m`, `30m`
 * Seconds: `90s`, `1500s`
 * Mixed: `25m30s`, `1h30m`
 
@@ -321,7 +322,7 @@ Duration values can be specified in the following formats:
 
 Settings are automatically applied when:
 * Starting a new Pomodoro (`pomodoro start`)
-* Taking a break (`pomodoro break`)
+* Taking a break (`pomodoro break` or `pomodoro finish --break`)
 * Displaying daily progress in status format (`%c/%g`)
 
 The daily goal setting is used by the status format parts `%g` (goal) and `%c` (completed today) to show progress toward your daily target.


### PR DESCRIPTION
Document the available configuration options in the go-openpomodoro library:
- daily_goal: Daily Pomodoro target count
- default_pomodoro_duration: Default work session duration
- default_break_duration: Default break duration
- default_tags: Default tags for new Pomodoros

Include example settings file, duration format guide, and usage information.

🤖 Generated with [Claude Code](https://claude.ai/code)